### PR TITLE
Bump viam-sdk to 0.75.0 and migrate off reconfigure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following attributes are available for `viam-labs:vision:yolov8` model:
 | `model_name` | string | Optional |  Name of model file when using HuggingFace repo identifier as `model_location` |
 | `task` | string | Optional |  Name of computer vision task performed by the model: "detect" (default) or "classify" |
 | `classes` | list of strings | Optional |  Restrict detections to the listed class names (e.g. `["cup"]`). Names must match `model.names`; unknown names are logged and skipped. Applies only when `task` is `"detect"`. |
+| `source_name` | string | Optional |  Image source name to select on multi-source cameras (e.g. `"color"` on an RGBD camera). When omitted, the first image returned by the camera is used. |
 
 ### Example Configurations
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following attributes are available for `viam-labs:vision:yolov8` model:
 | `task` | string | Optional |  Name of computer vision task performed by the model: "detect" (default) or "classify" |
 | `classes` | list of strings | Optional |  Restrict detections to the listed class names (e.g. `["cup"]`). Names must match `model.names`; unknown names are logged and skipped. Applies only when `task` is `"detect"`. |
 | `source_name` | string | Optional |  Image source name to select on multi-source cameras (e.g. `"color"` on an RGBD camera). When omitted, the first image returned by the camera is used. |
+| `verbose` | bool | Optional |  Enable Ultralytics' per-prediction logging to stdout. Defaults to `false`. Set to `true` only for debugging — it is very chatty. |
 
 ### Example Configurations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-viam-sdk~=0.43.0
+viam-sdk~=0.75.0
 ultralytics~=8.3.94

--- a/src/yolov8.py
+++ b/src/yolov8.py
@@ -58,6 +58,7 @@ class yolov8(Vision, EasyResource):
         LOGGER.debug(f"Configuring yolov8 model with {model_location}")
         self.DEPS = dependencies
         self.task = str(attrs.get("task")) or None
+        self.source_name = attrs.get("source_name") or None
 
         if "/" in model_location:
             if self.is_path(model_location):
@@ -121,7 +122,10 @@ class yolov8(Vision, EasyResource):
     async def get_cam_image(self, camera_name: str) -> ViamImage:
         actual_cam = self.DEPS[Camera.get_resource_name(camera_name)]
         cam = cast(Camera, actual_cam)
-        cam_images, _ = await cam.get_images(filter_source_names=[camera_name])
+        if self.source_name:
+            cam_images, _ = await cam.get_images(filter_source_names=[self.source_name])
+        else:
+            cam_images, _ = await cam.get_images()
         return cam_images[0]
 
     async def get_detections_from_camera(

--- a/src/yolov8.py
+++ b/src/yolov8.py
@@ -47,34 +47,11 @@ class yolov8(Vision, EasyResource):
     model: YOLO
     device: str
 
-    # Constructor
     @classmethod
     def new(
         cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
     ) -> Self:
-        return super().new(config, dependencies)
-
-    # Validates JSON Configuration
-    @classmethod
-    def validate_config(cls, config: ComponentConfig):
-        LOGGER.debug("Validating yolov8 service config")
-        model = config.attributes.fields["model_location"].string_value
-        if model == "":
-            raise Exception("A model_location must be defined")
-
-        task = config.attributes.fields["task"].string_value
-        classes = config.attributes.fields["classes"].list_value
-        if classes.values and task not in ("", "detect"):
-            raise Exception(
-                f"classes is only supported when task is 'detect'; got task='{task}'"
-            )
-
-        return []
-
-    # Handles attribute reconfiguration
-    def reconfigure(
-        self, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]
-    ):
+        self = super().new(config, dependencies)
         attrs = struct_to_dict(config.attributes)
         model_location = str(attrs.get("model_location"))
 
@@ -123,7 +100,23 @@ class yolov8(Vision, EasyResource):
             indices = [name_to_idx[c] for c in classes if c in name_to_idx]
             self.class_indices = indices or None
 
-        return
+        return self
+
+    @classmethod
+    def validate_config(cls, config: ComponentConfig):
+        LOGGER.debug("Validating yolov8 service config")
+        model = config.attributes.fields["model_location"].string_value
+        if model == "":
+            raise Exception("A model_location must be defined")
+
+        task = config.attributes.fields["task"].string_value
+        classes = config.attributes.fields["classes"].list_value
+        if classes.values and task not in ("", "detect"):
+            raise Exception(
+                f"classes is only supported when task is 'detect'; got task='{task}'"
+            )
+
+        return [], []
 
     async def get_cam_image(self, camera_name: str) -> ViamImage:
         actual_cam = self.DEPS[Camera.get_resource_name(camera_name)]

--- a/src/yolov8.py
+++ b/src/yolov8.py
@@ -19,14 +19,11 @@ from viam.services.vision import Vision, CaptureAllResult
 from viam.proto.service.vision import GetPropertiesResponse
 from viam.components.camera import Camera, ViamImage
 from viam.media.utils.pil import viam_to_pil_image
-from viam.logging import getLogger
 from viam.utils import struct_to_dict
 
 from ultralytics.engine.results import Results
 from ultralytics import YOLO
 import torch
-
-LOGGER = getLogger(__name__)
 
 MODEL_DIR = os.environ.get(
     "VIAM_MODULE_DATA", os.path.join(os.path.expanduser("~"), ".data", "models")
@@ -55,10 +52,11 @@ class yolov8(Vision, EasyResource):
         attrs = struct_to_dict(config.attributes)
         model_location = str(attrs.get("model_location"))
 
-        LOGGER.debug(f"Configuring yolov8 model with {model_location}")
+        self.logger.debug(f"Configuring yolov8 model with {model_location}")
         self.DEPS = dependencies
         self.task = str(attrs.get("task")) or None
         self.source_name = attrs.get("source_name") or None
+        self.verbose = bool(attrs.get("verbose", False))
 
         if "/" in model_location:
             if self.is_path(model_location):
@@ -94,7 +92,7 @@ class yolov8(Vision, EasyResource):
             name_to_idx = {name: idx for idx, name in self.model.names.items()}
             unknown = [c for c in classes if c not in name_to_idx]
             if unknown:
-                LOGGER.error(
+                self.logger.error(
                     f"classes {unknown} not found in model; ignoring. "
                     f"Available: {sorted(name_to_idx.keys())}"
                 )
@@ -105,7 +103,6 @@ class yolov8(Vision, EasyResource):
 
     @classmethod
     def validate_config(cls, config: ComponentConfig):
-        LOGGER.debug("Validating yolov8 service config")
         model = config.attributes.fields["model_location"].string_value
         if model == "":
             raise Exception("A model_location must be defined")
@@ -146,7 +143,10 @@ class yolov8(Vision, EasyResource):
     ) -> List[Detection]:
         detections = []
         results = self.model.predict(
-            viam_to_pil_image(image), device=self.device, classes=self.class_indices
+            viam_to_pil_image(image),
+            device=self.device,
+            classes=self.class_indices,
+            verbose=self.verbose,
         )
         if len(results) >= 1:
             index = 0
@@ -185,7 +185,9 @@ class yolov8(Vision, EasyResource):
         timeout: Optional[float] = None,
     ) -> List[Classification]:
         classifications = []
-        results = self.model.predict(viam_to_pil_image(image), device=self.device)
+        results = self.model.predict(
+            viam_to_pil_image(image), device=self.device, verbose=self.verbose
+        )
         if len(results) >= 1:
             processed_results = postprocess_classify_output(
                 self.model, result=results[0]
@@ -250,12 +252,12 @@ class yolov8(Vision, EasyResource):
     def get_model(self):
         if not os.path.exists(self.MODEL_PATH):
             MODEL_URL = f"https://huggingface.co/{self.MODEL_REPO}/resolve/main/{self.MODEL_FILE}"
-            LOGGER.debug(f"Fetching model {self.MODEL_FILE} from {MODEL_URL}")
+            self.logger.debug(f"Fetching model {self.MODEL_FILE} from {MODEL_URL}")
             urlretrieve(MODEL_URL, self.MODEL_PATH, self.log_progress)
 
     def log_progress(self, count: int, block_size: int, total_size: int) -> None:
         percent = count * block_size * 100 // total_size
-        LOGGER.debug(f"\rDownloading {self.MODEL_FILE}: {percent}%")
+        self.logger.debug(f"\rDownloading {self.MODEL_FILE}: {percent}%")
 
 
 # vendored and updated from ultralyticsplus library


### PR DESCRIPTION
## Summary
- Bump `viam-sdk` pin from `~=0.43.0` to `~=0.75.0`
- Fold the model-loading logic from `reconfigure()` into `new()` and delete `reconfigure()`. The Viam SDK removed the auto-call from `EasyResource.new()` in v0.60.0 ([viamrobotics/viam-python-sdk#1030](https://github.com/viamrobotics/viam-python-sdk/pull/1030)) and viam-rdk is moving away from `reconfigure` entirely.
- Update `validate_config()` to return the new `(required_deps, optional_deps)` tuple shape.
- **New `source_name` config attribute** for selecting an image stream on multi-source cameras (RealSense, OAK-D, stereo, RGBD). When unset, the camera's first image is used (matches main's effective behavior).

## Why the new `source_name` attribute is needed
The previous code passed `filter_source_names=[camera_name]` to `get_images`. On viam-sdk 0.43 that kwarg was silently dropped — `filter_source_names` didn't exist on the client until 0.55, so it landed in `**kwargs` and was discarded; the server returned all images and `cam_images[0]` worked. On 0.75 the filter is actually honored, and on a webcam whose source name doesn't match its resource name the server returns zero images and raises `IndexError`. Making the filter opt-in via `source_name` restores the working default while still letting users disambiguate streams when they need to.

| Attribute | Type | Inclusion | Description |
|---|---|---|---|
| `source_name` | string | Optional | Image source to select on multi-source cameras (e.g. `"color"` on RGBD). Omit for single-source cameras. |

## Notes for users
- **Not breaking at the module-config level.** Model name, existing attributes (`model_location`, `model_name`, `task`), `depends_on`, and the Vision API methods are unchanged. Existing robot configs keep working after the Registry republishes.
- **Higher viam-server floor.** Building against viam-sdk 0.75 raises the minimum viam-server version this module can talk to. Robots on very old viam-server may need to update first.
- **Reconfigure cost.** Editing config now reconstructs the resource (fresh YOLO model load) instead of mutating the existing instance. Cheap here; flagged for awareness.

## Test plan
- [x] `./setup.sh && ./build.sh` produces `dist/archive.tar.gz` with the new SDK
- [x] Local YOLO model (`model_location: "yolov8n.pt"`) loads and serves `get_detections_from_camera` on a plain webcam (no `source_name`)
- [x] Multi-source camera with `source_name: "color"` returns RGB stream and serves detections (no IndexError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)