### PR TITLE
Add optional classes filter for detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following attributes are available for `viam-labs:vision:yolov8` model:
 | `model_location` | string | **Required** |  YOLO model name (such as "yolov8n.pt"), local path to model, or HuggingFace model repo identifier |
 | `model_name` | string | Optional |  Name of model file when using HuggingFace repo identifier as `model_location` |
 | `task` | string | Optional |  Name of computer vision task performed by the model: "detect" (default) or "classify" |
+| `classes` | list of strings | Optional |  Restrict detections to the listed class names (e.g. `["cup"]`). Names must match `model.names`; unknown names are logged and skipped. Applies only when `task` is `"detect"`. |
 
 ### Example Configurations
 

--- a/src/yolov8.py
+++ b/src/yolov8.py
@@ -61,6 +61,14 @@ class yolov8(Vision, EasyResource):
         model = config.attributes.fields["model_location"].string_value
         if model == "":
             raise Exception("A model_location must be defined")
+
+        task = config.attributes.fields["task"].string_value
+        classes = config.attributes.fields["classes"].list_value
+        if classes.values and task not in ("", "detect"):
+            raise Exception(
+                f"classes is only supported when task is 'detect'; got task='{task}'"
+            )
+
         return []
 
     # Handles attribute reconfiguration

--- a/src/yolov8.py
+++ b/src/yolov8.py
@@ -102,6 +102,19 @@ class yolov8(Vision, EasyResource):
         if torch.cuda.is_available():
             self.device = torch.cuda.current_device()
 
+        self.class_indices = None
+        classes = attrs.get("classes")
+        if classes:
+            name_to_idx = {name: idx for idx, name in self.model.names.items()}
+            unknown = [c for c in classes if c not in name_to_idx]
+            if unknown:
+                LOGGER.error(
+                    f"classes {unknown} not found in model; ignoring. "
+                    f"Available: {sorted(name_to_idx.keys())}"
+                )
+            indices = [name_to_idx[c] for c in classes if c in name_to_idx]
+            self.class_indices = indices or None
+
         return
 
     async def get_cam_image(self, camera_name: str) -> ViamImage:
@@ -127,7 +140,9 @@ class yolov8(Vision, EasyResource):
         timeout: Optional[float] = None,
     ) -> List[Detection]:
         detections = []
-        results = self.model.predict(viam_to_pil_image(image), device=self.device)
+        results = self.model.predict(
+            viam_to_pil_image(image), device=self.device, classes=self.class_indices
+        )
         if len(results) >= 1:
             index = 0
             result = results[0]


### PR DESCRIPTION
## Summary
- New optional `classes` config attribute (list of class name strings) that restricts detection output to the listed classes — e.g. `"classes": ["cup"]` returns only cup boxes.
- Resolved against `self.model.names` at config time and passed to Ultralytics' `predict(classes=[...])`, which filters at inference time (cheaper than post-filter).
- Unknown names are logged and skipped, not raised — a partially-valid list still works. If every name is unknown, the filter falls back to `None` (no filtering) so detection doesn't silently return zero results.

## Why detection-only
Ultralytics' `classes` predict-time kwarg only applies to detection. A YOLO model is trained for one task at a time (set by `task`), so a deployed service is either doing detection or classification — not both. Classification users have `count` to bound output and aren't covered here; can be added later if anyone needs name-based filtering on a classify model.

## Example
```json
{
  "model_location": "yolov8n.pt",
  "classes": ["cup"]
}
```

## Test plan
- [x] `"classes": ["cup"]` on `yolov8n.pt` returns only cup detections (no `person`, `bottle`, etc.)
- [x] Multiple names: `"classes": ["cup", "person"]` returns both classes
- [ ] Mixed valid + invalid: `"classes": ["cup", "cuup"]` logs an error for `cuup`, still returns cup detections
- [ ] All-invalid: `"classes": ["foo"]` logs an error and detections fall back to unfiltered
- [x] Omitting `classes` entirely keeps existing behavior (all detections returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)